### PR TITLE
Split perNodeHostBits per IP family.

### DIFF
--- a/charts/node-ipam-controller/gen/crds/networking.x-k8s.io_clustercidrs.yaml
+++ b/charts/node-ipam-controller/gen/crds/networking.x-k8s.io_clustercidrs.yaml
@@ -138,18 +138,28 @@ spec:
                 - nodeSelectorTerms
                 type: object
                 x-kubernetes-map-type: atomic
-              perNodeHostBits:
-                description: perNodeHostBits defines the number of host bits to be
-                  configured per node. A subnet mask determines how much of the address
-                  is used for network bits and host bits. For example an IPv4 address
-                  of 192.168.0.0/24, splits the address into 24 bits for the network
-                  portion and 8 bits for the host portion. To allocate 256 IPs, set
-                  this field to 8 (a /24 mask for IPv4 or a /120 for IPv6). Minimum
-                  value is 4 (16 IPs). This field is required and immutable.
+              perNodeHostBits4:
+                description: perNodeHostBits4 defines the number of host bits to be
+                  configured per node when IPv4 family is used. A subnet mask determines
+                  how much of the address is used for network bits and host bits.
+                  For example an IPv4 address of 192.168.0.0/24, splits the address
+                  into 24 bits for the network portion and 8 bits for the host portion.
+                  To allocate 256 IPs, set this field to 8 (a /24 mask). Minimum value
+                  is 4 (16 IPs). This field is required when IPv4 family is used and
+                  immutable.
                 format: int32
                 type: integer
-            required:
-            - perNodeHostBits
+              perNodeHostBits6:
+                description: perNodeHostBits6 defines the number of host bits to be
+                  configured per node when IPv6 family is used. A subnet mask determines
+                  how much of the address is used for network bits and host bits.
+                  For example an IPv4 address of 192.168.0.0/24, splits the address
+                  into 24 bits for the network portion and 8 bits for the host portion.
+                  To allocate 256 IPs, set this field to 8 (a /120 mask). Minimum
+                  value is 4 (16 IPs). This field is required when IPv6 family is
+                  used and immutable.
+                format: int32
+                type: integer
             type: object
         type: object
     served: true

--- a/pkg/apis/clustercidr/v1/types.go
+++ b/pkg/apis/clustercidr/v1/types.go
@@ -54,16 +54,25 @@ type ClusterCIDRSpec struct {
 	// +optional
 	NodeSelector *api.NodeSelector `json:"nodeSelector,omitempty"`
 
-	// perNodeHostBits defines the number of host bits to be configured per node.
+	// perNodeHostBits4 defines the number of host bits to be configured per node when IPv4 family is used.
 	// A subnet mask determines how much of the address is used for network bits
 	// and host bits. For example an IPv4 address of 192.168.0.0/24, splits the
 	// address into 24 bits for the network portion and 8 bits for the host portion.
-	// To allocate 256 IPs, set this field to 8 (a /24 mask for IPv4 or a /120 for IPv6).
+	// To allocate 256 IPs, set this field to 8 (a /24 mask).
 	// Minimum value is 4 (16 IPs).
-	// This field is required and immutable.
-	// +kubebuilder:validation:Required
-	// +required
-	PerNodeHostBits int32 `json:"perNodeHostBits"`
+	// This field is required when IPv4 family is used and immutable.
+	// +optional
+	PerNodeHostBits4 int32 `json:"perNodeHostBits4"`
+
+	// perNodeHostBits6 defines the number of host bits to be configured per node when IPv6 family is used.
+	// A subnet mask determines how much of the address is used for network bits
+	// and host bits. For example an IPv4 address of 192.168.0.0/24, splits the
+	// address into 24 bits for the network portion and 8 bits for the host portion.
+	// To allocate 256 IPs, set this field to 8 (a /120 mask).
+	// Minimum value is 4 (16 IPs).
+	// This field is required when IPv6 family is used and immutable.
+	// +optional
+	PerNodeHostBits6 int32 `json:"perNodeHostBits6"`
 
 	// ipv4 defines an IPv4 IP block in CIDR notation(e.g. "10.0.0.0/8").
 	// At least one of ipv4 and ipv6 must be specified.

--- a/pkg/apis/clustercidr/v1/validation/validation.go
+++ b/pkg/apis/clustercidr/v1/validation/validation.go
@@ -57,14 +57,14 @@ func ValidateClusterCIDRSpec(spec *v1.ClusterCIDRSpec, fldPath *field.Path) fiel
 		return allErrs
 	}
 
-	// Validate specified IPv4 CIDR and PerNodeHostBits.
+	// Validate specified IPv4 CIDR and PerNodeHostBits4.
 	if spec.IPv4 != "" {
-		allErrs = append(allErrs, validateCIDRConfig(spec.IPv4, spec.PerNodeHostBits, 32, corev1.IPv4Protocol, fldPath)...)
+		allErrs = append(allErrs, validateCIDRConfig(spec.IPv4, spec.PerNodeHostBits4, 32, corev1.IPv4Protocol, fldPath)...)
 	}
 
-	// Validate specified IPv6 CIDR and PerNodeHostBits.
+	// Validate specified IPv6 CIDR and PerNodeHostBits6.
 	if spec.IPv6 != "" {
-		allErrs = append(allErrs, validateCIDRConfig(spec.IPv6, spec.PerNodeHostBits, 128, corev1.IPv6Protocol, fldPath)...)
+		allErrs = append(allErrs, validateCIDRConfig(spec.IPv6, spec.PerNodeHostBits6, 128, corev1.IPv6Protocol, fldPath)...)
 	}
 
 	return allErrs
@@ -91,11 +91,18 @@ func validateCIDRConfig(configCIDR string, perNodeHostBits, maxMaskSize int32, i
 	maskSize, _ := ipNet.Mask.Size()
 	maxPerNodeHostBits := maxMaskSize - int32(maskSize)
 
+	var perNodeHostBitsFieldName string
+	if ipFamily == corev1.IPv4Protocol {
+		perNodeHostBitsFieldName = "perNodeHostBits4"
+	} else {
+		perNodeHostBitsFieldName = "perNodeHostBits6"
+	}
+
 	if perNodeHostBits < minPerNodeHostBits {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("perNodeHostBits"), perNodeHostBits, fmt.Sprintf("must be greater than or equal to %d", minPerNodeHostBits)))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child(perNodeHostBitsFieldName), perNodeHostBits, fmt.Sprintf("must be greater than or equal to %d", minPerNodeHostBits)))
 	}
 	if perNodeHostBits > maxPerNodeHostBits {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("perNodeHostBits"), perNodeHostBits, fmt.Sprintf("must be less than or equal to %d", maxPerNodeHostBits)))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child(perNodeHostBitsFieldName), perNodeHostBits, fmt.Sprintf("must be less than or equal to %d", maxPerNodeHostBits)))
 	}
 	return allErrs
 }
@@ -112,7 +119,8 @@ func validateClusterCIDRUpdateSpec(update, old *v1.ClusterCIDRSpec, fldPath *fie
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(update.NodeSelector, old.NodeSelector, fldPath.Child("nodeSelector"))...)
-	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(update.PerNodeHostBits, old.PerNodeHostBits, fldPath.Child("perNodeHostBits"))...)
+	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(update.PerNodeHostBits4, old.PerNodeHostBits4, fldPath.Child("perNodeHostBits4"))...)
+	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(update.PerNodeHostBits6, old.PerNodeHostBits6, fldPath.Child("perNodeHostBits6"))...)
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(update.IPv4, old.IPv4, fldPath.Child("ipv4"))...)
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(update.IPv6, old.IPv6, fldPath.Child("ipv6"))...)
 

--- a/pkg/apis/clustercidr/v1/validation/validation_test.go
+++ b/pkg/apis/clustercidr/v1/validation/validation_test.go
@@ -38,16 +38,21 @@ func makeNodeSelector(key string, op corev1.NodeSelectorOperator, values []strin
 }
 
 func makeClusterCIDR(perNodeHostBits int32, ipv4, ipv6 string, nodeSelector *corev1.NodeSelector) *v1.ClusterCIDR {
+	return makeClusterCIDRWithBits(perNodeHostBits, perNodeHostBits, ipv4, ipv6, nodeSelector)
+}
+
+func makeClusterCIDRWithBits(perNodeHostBits4, perNodeHostBits6 int32, ipv4, ipv6 string, nodeSelector *corev1.NodeSelector) *v1.ClusterCIDR {
 	return &v1.ClusterCIDR{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
 			ResourceVersion: "9",
 		},
 		Spec: v1.ClusterCIDRSpec{
-			PerNodeHostBits: perNodeHostBits,
-			IPv4:            ipv4,
-			IPv6:            ipv6,
-			NodeSelector:    nodeSelector,
+			PerNodeHostBits4: perNodeHostBits4,
+			PerNodeHostBits6: perNodeHostBits6,
+			IPv4:             ipv4,
+			IPv6:             ipv6,
+			NodeSelector:     nodeSelector,
 		},
 	}
 }
@@ -199,8 +204,12 @@ func TestValidateClusterConfigUpdate(t *testing.T) {
 		cc:        makeClusterCIDR(8, "10.1.0.0/16", "fd00:1:1::/64", makeNodeSelector("foo", corev1.NodeSelectorOpIn, []string{"bar"})),
 		expectErr: false,
 	}, {
-		name:      "Failed update, update spec.PerNodeHostBits",
+		name:      "Failed update, update spec.PerNodeHostBits4",
 		cc:        makeClusterCIDR(12, "10.1.0.0/16", "fd00:1:1::/64", makeNodeSelector("foo", corev1.NodeSelectorOpIn, []string{"bar"})),
+		expectErr: true,
+	}, {
+		name:      "Failed update, update spec.PerNodeHostBits6",
+		cc:        makeClusterCIDRWithBits(8, 12, "10.1.0.0/16", "fd00:1:1::/64", makeNodeSelector("foo", corev1.NodeSelectorOpIn, []string{"bar"})),
 		expectErr: true,
 	}, {
 		name:      "Failed update, update spec.IPv4",

--- a/pkg/controller/ipam/ipam_suite_test.go
+++ b/pkg/controller/ipam/ipam_suite_test.go
@@ -75,15 +75,21 @@ var _ = ginkgo.AfterSuite(func() {
 
 // makeClusterCIDR returns a ClusterCIDR object.
 func makeClusterCIDR(name, ipv4CIDR, ipv6CIDR string, perNodeHostBits int32, nodeSelector *corev1.NodeSelector) *v1.ClusterCIDR {
+	return makeClusterCIDRWithBits(name, ipv4CIDR, ipv6CIDR, perNodeHostBits, perNodeHostBits, nodeSelector)
+}
+
+// makeClusterCIDRWithBits returns a ClusterCIDR object.
+func makeClusterCIDRWithBits(name, ipv4CIDR, ipv6CIDR string, perNodeHostBits4, perNodeHostBits6 int32, nodeSelector *corev1.NodeSelector) *v1.ClusterCIDR {
 	return &v1.ClusterCIDR{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: v1.ClusterCIDRSpec{
-			PerNodeHostBits: perNodeHostBits,
-			IPv4:            ipv4CIDR,
-			IPv6:            ipv6CIDR,
-			NodeSelector:    nodeSelector,
+			PerNodeHostBits4: perNodeHostBits4,
+			PerNodeHostBits6: perNodeHostBits6,
+			IPv4:             ipv4CIDR,
+			IPv6:             ipv6CIDR,
+			NodeSelector:     nodeSelector,
 		},
 	}
 }

--- a/pkg/controller/ipam/ipam_test.go
+++ b/pkg/controller/ipam/ipam_test.go
@@ -283,7 +283,7 @@ var _ = ginkgo.Describe("Pod CIDRs", ginkgo.Ordered, func() {
 			makeNode("dualstack-node", map[string]string{"ipv4": "true", "ipv6": "true", "match": "single"}),
 			[]string{"172.16.0.0/24", "fd34:30:100::/120"},
 		),
-		ginkgo.Entry("ClusterCIDR with lower perNodeHostBits",
+		ginkgo.Entry("ClusterCIDR with lower perNodeHostBits4",
 			[]*v1.ClusterCIDR{
 				makeClusterCIDR("single-label-match-cc", "192.168.0.0/23", "fd00:30:100::/119", 8, nodeSelector(map[string][]string{"match": {"single"}})),
 				makeClusterCIDR("double-label-match-cc", "10.0.0.0/20", "fd12:30:200::/116", 8, nodeSelector(map[string][]string{"ipv4": {"true"}, "ipv6": {"true"}})),

--- a/pkg/controller/ipam/multi_cidr_range_allocator_test.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator_test.go
@@ -59,10 +59,11 @@ type testCaseMultiCIDR struct {
 }
 
 type testClusterCIDR struct {
-	perNodeHostBits int32
-	ipv4CIDR        string
-	ipv6CIDR        string
-	name            string
+	perNodeHostBits4 int32
+	perNodeHostBits6 int32
+	ipv4CIDR         string
+	ipv6CIDR         string
+	name             string
 }
 
 type testNodeSelectorRequirement struct {
@@ -103,12 +104,12 @@ func getTestCidrMap(testClusterCIDRMap map[string][]*testClusterCIDR) map[string
 
 			if testClusterCIDR.ipv4CIDR != "" {
 				_, testCIDR, _ := utilnet.ParseCIDRSloppy(testClusterCIDR.ipv4CIDR)
-				testCIDRSet, _ := multicidrset.NewMultiCIDRSet(testCIDR, int(testClusterCIDR.perNodeHostBits))
+				testCIDRSet, _ := multicidrset.NewMultiCIDRSet(testCIDR, int(testClusterCIDR.perNodeHostBits4))
 				clusterCIDR.IPv4CIDRSet = testCIDRSet
 			}
 			if testClusterCIDR.ipv6CIDR != "" {
 				_, testCIDR, _ := utilnet.ParseCIDRSloppy(testClusterCIDR.ipv6CIDR)
-				testCIDRSet, _ := multicidrset.NewMultiCIDRSet(testCIDR, int(testClusterCIDR.perNodeHostBits))
+				testCIDRSet, _ := multicidrset.NewMultiCIDRSet(testCIDR, int(testClusterCIDR.perNodeHostBits6))
 				clusterCIDR.IPv6CIDRSet = testCIDRSet
 			}
 			clusterCIDRList = append(clusterCIDRList, clusterCIDR)
@@ -164,9 +165,9 @@ func TestMultiCIDROccupyPreExistingCIDR(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "single-stack-cidr",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.10.0.0/16",
+							name:             "single-stack-cidr",
+							perNodeHostBits4: 8,
+							ipv4CIDR:         "10.10.0.0/16",
 						},
 					},
 				}),
@@ -203,10 +204,10 @@ func TestMultiCIDROccupyPreExistingCIDR(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.10.0.0/16",
-							ipv6CIDR:        "ace:cab:deca::/112",
+							name:             "dual-stack-cidr",
+							perNodeHostBits4: 8,
+							ipv4CIDR:         "10.10.0.0/16",
+							ipv6CIDR:         "ace:cab:deca::/112",
 						},
 					},
 				}),
@@ -246,9 +247,9 @@ func TestMultiCIDROccupyPreExistingCIDR(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "single-stack-cidr-allocated",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.10.0.0/16",
+							name:             "single-stack-cidr-allocated",
+							perNodeHostBits4: 8,
+							ipv4CIDR:         "10.10.0.0/16",
 						},
 					},
 				}),
@@ -288,10 +289,10 @@ func TestMultiCIDROccupyPreExistingCIDR(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-allocated",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.10.0.0/16",
-							ipv6CIDR:        "ace:cab:deca::/112",
+							name:             "dual-stack-cidr-allocated",
+							perNodeHostBits4: 8,
+							ipv4CIDR:         "10.10.0.0/16",
+							ipv6CIDR:         "ace:cab:deca::/112",
 						},
 					},
 				}),
@@ -332,9 +333,9 @@ func TestMultiCIDROccupyPreExistingCIDR(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "single-stack-cidr-allocate-fail",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.10.0.0/16",
+							name:             "single-stack-cidr-allocate-fail",
+							perNodeHostBits4: 8,
+							ipv4CIDR:         "10.10.0.0/16",
 						},
 					},
 				}),
@@ -375,10 +376,10 @@ func TestMultiCIDROccupyPreExistingCIDR(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-allocate-fail",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.10.0.0/16",
-							ipv6CIDR:        "ace:cab:deca::/112",
+							name:             "dual-stack-cidr-allocate-fail",
+							perNodeHostBits4: 8,
+							ipv4CIDR:         "10.10.0.0/16",
+							ipv6CIDR:         "ace:cab:deca::/112",
 						},
 					},
 				}),
@@ -419,10 +420,10 @@ func TestMultiCIDROccupyPreExistingCIDR(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-bad-v4",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.10.0.0/16",
-							ipv6CIDR:        "ace:cab:deca::/112",
+							name:             "dual-stack-cidr-bad-v4",
+							perNodeHostBits4: 8,
+							ipv4CIDR:         "10.10.0.0/16",
+							ipv6CIDR:         "ace:cab:deca::/112",
 						},
 					},
 				}),
@@ -463,10 +464,10 @@ func TestMultiCIDROccupyPreExistingCIDR(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-bad-v6",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.10.0.0/16",
-							ipv6CIDR:        "ace:cab:deca::/112",
+							name:             "dual-stack-cidr-bad-v6",
+							perNodeHostBits4: 8,
+							ipv4CIDR:         "10.10.0.0/16",
+							ipv6CIDR:         "ace:cab:deca::/112",
 						},
 					},
 				}),
@@ -497,8 +498,6 @@ func TestMultiCIDROccupyPreExistingCIDR(t *testing.T) {
 		})
 	}
 }
-
-// todo(mneverov): copied from cidr_allocator
 
 // nodePollInterval is used in listing node
 // This is a variable instead of a const to enable testing.
@@ -543,9 +542,9 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "single-stack-cidr",
-							perNodeHostBits: 2,
-							ipv4CIDR:        "127.123.234.0/24",
+							name:             "single-stack-cidr",
+							perNodeHostBits4: 2,
+							ipv4CIDR:         "127.123.234.0/24",
 						},
 					},
 				}),
@@ -586,9 +585,9 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "single-stack-cidr",
-							perNodeHostBits: 2,
-							ipv4CIDR:        "127.123.234.0/24",
+							name:             "single-stack-cidr",
+							perNodeHostBits4: 2,
+							ipv4CIDR:         "127.123.234.0/24",
 						},
 					},
 				}),
@@ -629,9 +628,9 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "single-stack-cidr",
-							perNodeHostBits: 2,
-							ipv4CIDR:        "127.123.234.0/24",
+							name:             "single-stack-cidr",
+							perNodeHostBits4: 2,
+							ipv4CIDR:         "127.123.234.0/24",
 						},
 					},
 				}),
@@ -676,10 +675,11 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-1",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.0.0.0/8",
-							ipv6CIDR:        "ace:cab:deca::/112",
+							name:             "dual-stack-cidr-1",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 12,
+							ipv4CIDR:         "10.0.0.0/8",
+							ipv6CIDR:         "ace:cab:deca::/112",
 						},
 					},
 					getTestNodeSelector([]testNodeSelectorRequirement{
@@ -695,16 +695,17 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-2",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "127.123.234.0/8",
-							ipv6CIDR:        "abc:def:deca::/112",
+							name:             "dual-stack-cidr-2",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 12,
+							ipv4CIDR:         "127.123.234.0/8",
+							ipv6CIDR:         "abc:def:deca::/112",
 						},
 					},
 				}),
 			expectedAllocatedCIDR: map[int]string{
 				0: "127.0.0.0/24",
-				1: "abc:def:deca::/120",
+				1: "abc:def:deca::/116",
 			},
 		},
 		{
@@ -741,10 +742,11 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-1",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.0.0.0/8",
-							ipv6CIDR:        "ace:cab:deca::/112",
+							name:             "dual-stack-cidr-1",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 12,
+							ipv4CIDR:         "10.0.0.0/8",
+							ipv6CIDR:         "ace:cab:deca::/112",
 						},
 					},
 					getTestNodeSelector([]testNodeSelectorRequirement{
@@ -760,20 +762,21 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-2",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.0.0.0/16",
-							ipv6CIDR:        "ace:cab:deca::/112",
+							name:             "dual-stack-cidr-2",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 12,
+							ipv4CIDR:         "10.0.0.0/16",
+							ipv6CIDR:         "ace:cab:deca::/112",
 						},
 					},
 				}),
 			allocatedCIDRs: map[int][]string{
 				0: {"10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24", "10.0.4.0/24"},
-				1: {"ace:cab:deca::/120"},
+				1: {"ace:cab:deca::/116"},
 			},
 			expectedAllocatedCIDR: map[int]string{
 				0: "10.0.3.0/24",
-				1: "ace:cab:deca::100/120",
+				1: "ace:cab:deca::1000/116",
 			},
 		},
 		{
@@ -815,10 +818,11 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-1",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "127.123.234.0/8",
-							ipv6CIDR:        "abc:def:deca::/112",
+							name:             "dual-stack-cidr-1",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 8,
+							ipv4CIDR:         "127.123.234.0/8",
+							ipv6CIDR:         "abc:def:deca::/112",
 						},
 					},
 					getTestNodeSelector([]testNodeSelectorRequirement{
@@ -834,10 +838,11 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-2",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.0.0.0/24",
-							ipv6CIDR:        "ace:cab:deca::/120",
+							name:             "dual-stack-cidr-2",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 8,
+							ipv4CIDR:         "10.0.0.0/24",
+							ipv6CIDR:         "ace:cab:deca::/120",
 						},
 					},
 				}),
@@ -885,9 +890,10 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-1",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "127.123.234.0/23",
+							name:             "dual-stack-cidr-1",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 8,
+							ipv4CIDR:         "127.123.234.0/23",
 						},
 					},
 					getTestNodeSelector([]testNodeSelectorRequirement{
@@ -903,10 +909,11 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-2",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.0.0.0/16",
-							ipv6CIDR:        "ace:cab:deca::/120",
+							name:             "dual-stack-cidr-2",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 8,
+							ipv4CIDR:         "10.0.0.0/16",
+							ipv6CIDR:         "ace:cab:deca::/120",
 						},
 					},
 				}),
@@ -954,10 +961,10 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-1",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "127.123.234.0/24",
-							ipv6CIDR:        "abc:def:deca::/120",
+							name:             "dual-stack-cidr-1",
+							perNodeHostBits4: 8,
+							ipv4CIDR:         "127.123.234.0/24",
+							ipv6CIDR:         "abc:def:deca::/120",
 						},
 					},
 					getTestNodeSelector([]testNodeSelectorRequirement{
@@ -973,10 +980,10 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-2",
-							perNodeHostBits: 0,
-							ipv4CIDR:        "10.0.0.0/32",
-							ipv6CIDR:        "ace:cab:deca::/128",
+							name:             "dual-stack-cidr-2",
+							perNodeHostBits4: 0,
+							ipv4CIDR:         "10.0.0.0/32",
+							ipv6CIDR:         "ace:cab:deca::/128",
 						},
 					},
 				}),
@@ -1024,10 +1031,11 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-1",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "127.123.234.0/16",
-							ipv6CIDR:        "abc:def:deca::/112",
+							name:             "dual-stack-cidr-1",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 8,
+							ipv4CIDR:         "127.123.234.0/16",
+							ipv6CIDR:         "abc:def:deca::/112",
 						},
 					},
 					getTestNodeSelector([]testNodeSelectorRequirement{
@@ -1043,10 +1051,11 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-2",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.0.0.0/16",
-							ipv6CIDR:        "ace:cab:deca::/112",
+							name:             "dual-stack-cidr-2",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 8,
+							ipv4CIDR:         "10.0.0.0/16",
+							ipv6CIDR:         "ace:cab:deca::/112",
 						},
 					},
 				}),
@@ -1094,10 +1103,11 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-1",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "127.123.234.0/16",
-							ipv6CIDR:        "abc:def:deca::/112",
+							name:             "dual-stack-cidr-1",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 8,
+							ipv4CIDR:         "127.123.234.0/16",
+							ipv6CIDR:         "abc:def:deca::/112",
 						},
 					},
 					getTestNodeSelector([]testNodeSelectorRequirement{
@@ -1113,10 +1123,11 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "dual-stack-cidr-2",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.0.0.0/16",
-							ipv6CIDR:        "ace:cab:deca::/112",
+							name:             "dual-stack-cidr-2",
+							perNodeHostBits4: 8,
+							perNodeHostBits6: 8,
+							ipv4CIDR:         "10.0.0.0/16",
+							ipv6CIDR:         "ace:cab:deca::/112",
 						},
 					},
 				}),
@@ -1176,9 +1187,9 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "no-double-counting",
-							perNodeHostBits: 8,
-							ipv4CIDR:        "10.10.0.0/22",
+							name:             "no-double-counting",
+							perNodeHostBits4: 8,
+							ipv4CIDR:         "10.10.0.0/22",
 						},
 					},
 				}),
@@ -1210,8 +1221,6 @@ func TestMultiCIDRAllocateOrOccupyCIDRSuccess(t *testing.T) {
 			return
 		}
 		rangeAllocator.nodesSynced = test.AlwaysReady
-		// todo(mneverov)
-		// rangeAllocator.recorder = test.NewFakeRecorder()
 		rangeAllocator.recorder = &record.FakeRecorder{}
 
 		// this is a bit of white box testing
@@ -1312,9 +1321,9 @@ func TestMultiCIDRAllocateOrOccupyCIDRFailure(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "allocate-fail",
-							perNodeHostBits: 2,
-							ipv4CIDR:        "127.123.234.0/28",
+							name:             "allocate-fail",
+							perNodeHostBits4: 2,
+							ipv4CIDR:         "127.123.234.0/28",
 						},
 					},
 				}),
@@ -1450,9 +1459,9 @@ func TestMultiCIDRReleaseCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "cidr-release",
-							perNodeHostBits: 2,
-							ipv4CIDR:        "127.123.234.0/28",
+							name:             "cidr-release",
+							perNodeHostBits4: 2,
+							ipv4CIDR:         "127.123.234.0/28",
 						},
 					},
 				}),
@@ -1496,9 +1505,9 @@ func TestMultiCIDRReleaseCIDRSuccess(t *testing.T) {
 						},
 					}): {
 						{
-							name:            "cidr-release",
-							perNodeHostBits: 2,
-							ipv4CIDR:        "127.123.234.0/28",
+							name:             "cidr-release",
+							perNodeHostBits4: 2,
+							ipv4CIDR:         "127.123.234.0/28",
 						},
 					},
 				}),
@@ -1691,6 +1700,8 @@ func newController(ctx context.Context) (*clustercidrfake.Clientset, *nodeIPAMCo
 // Ensure default ClusterCIDR is created during bootstrap.
 func TestClusterCIDRDefault(t *testing.T) {
 	defaultCCC := makeClusterCIDR(defaultClusterCIDRName, "192.168.0.0/16", "", 8, nil)
+	// By default PerNodeHostBits (for both IPv4 and IPv6) equals to 4 (minPerHostBits).
+	defaultCCC.Spec.PerNodeHostBits6 = 4
 	_, ctx := ktesting.NewTestContext(t)
 	client, _ := newController(ctx)
 	createdCCC, err := client.NetworkingV1().ClusterCIDRs().Get(context.TODO(), defaultClusterCIDRName, metav1.GetOptions{})
@@ -1737,17 +1748,17 @@ func TestSyncClusterCIDRCreate(t *testing.T) {
 		},
 		{
 			name:    "valid Dualstack ClusterCIDR with no NodeSelector",
-			ccc:     makeClusterCIDR("dual-ccc", "10.2.0.0/16", "fd00:1::/112", 8, nil),
+			ccc:     makeClusterCIDRWithBits("dual-ccc", "10.2.0.0/16", "fd00:1::/112", 8, 12, nil),
 			wantErr: false,
 		},
 		{
 			name:    "valid DualStack ClusterCIDR with NodeSelector",
-			ccc:     makeClusterCIDR("dual-ccc-label", "10.3.0.0/16", "fd00:2::/112", 8, makeNodeSelector("foo", corev1.NodeSelectorOpIn, []string{"bar"})),
+			ccc:     makeClusterCIDRWithBits("dual-ccc-label", "10.3.0.0/16", "fd00:2::/112", 8, 12, makeNodeSelector("foo", corev1.NodeSelectorOpIn, []string{"bar"})),
 			wantErr: false,
 		},
 		{
 			name:    "valid Dualstack ClusterCIDR with overlapping CIDRs",
-			ccc:     makeClusterCIDR("dual-ccc-overlap", "10.2.0.0/16", "fd00:1:1::/112", 8, makeNodeSelector("foo", corev1.NodeSelectorOpIn, []string{"bar"})),
+			ccc:     makeClusterCIDRWithBits("dual-ccc-overlap", "10.2.0.0/16", "fd00:1:1::/112", 8, 12, makeNodeSelector("foo", corev1.NodeSelectorOpIn, []string{"bar"})),
 			wantErr: false,
 		},
 		// invalid ClusterCIDRs.

--- a/samples/clustercidr-dual.yaml
+++ b/samples/clustercidr-dual.yaml
@@ -3,6 +3,7 @@ kind: ClusterCIDR
 metadata:
   name: clustercidr-test
 spec:
-  perNodeHostBits: 8
+  perNodeHostBits4: 8
+  perNodeHostBits6: 8
   ipv4: 10.244.0.0/16
   ipv6: 2001:db8::/110

--- a/samples/clustercidr-ipv4.yaml
+++ b/samples/clustercidr-ipv4.yaml
@@ -3,5 +3,5 @@ kind: ClusterCIDR
 metadata:
   name: clustercidr-test
 spec:
-  perNodeHostBits: 8
+  perNodeHostBits4: 8
   ipv4: 10.244.0.0/16

--- a/samples/clustercidr-ipv6.yaml
+++ b/samples/clustercidr-ipv6.yaml
@@ -3,5 +3,5 @@ kind: ClusterCIDR
 metadata:
   name: clustercidr-test
 spec:
-  perNodeHostBits: 8
+  perNodeHostBits6: 8
   ipv6: 2001:db8::/110


### PR DESCRIPTION
This patch splits `perNodeHostBits` to two fields one for each IP family. Both new fields are `optional` (`perNodeHostBits` was required) because they are only checked if a ClusterCIDR of the corresponding IP family was submitted. The min-max check [stays the same](https://github.com/kubernetes-sigs/node-ipam-controller/pull/9/files#diff-768700b1f66271fe29ff246042554692c3d339b0979ccd514788e21aeb9afc85R101). If the bits field was not provided (i.e. populated with a default `0` value) the min check will fail ([test](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/pkg/apis/clustercidr/v1/validation/validation_test.go#L150) exists).
I wonder if we want to split [NodeCIDRMaskSizes](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/pkg/controller/ipam/multi_cidr_range_allocator.go#L111) per IP family too?

resolves #5.