### PR TITLE
Fix flaky test: wait until the CIDR created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ KUBEBUILDER_ASSETS=$(shell go run sigs.k8s.io/controller-runtime/tools/setup-env
 
 .PHONY: test
 test: manifests generate fmt ## Run tests.
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./... -coverprofile cover.out -v
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -coverprofile cover.out -v ./...
 
 ##@ Build
 

--- a/pkg/controller/ipam/ipam_suite_test.go
+++ b/pkg/controller/ipam/ipam_suite_test.go
@@ -36,7 +36,15 @@ var (
 
 func TestAPIs(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Node IPAM Controller Suite")
+	// ginkgo only prints test names and output when either tests failed or when ginkgo run with -ginkgo.v (verbose).
+	// When running test with `go test -v ./... -ginkgo.v` each package is built and run as a separate binary, hence
+	// for all other packages but node-ipam-controller/pkg/controller/ipam the flag `-ginkgo.v` is unknown, which lead
+	// to error "flag provided but not defined: -ginkgo.v".
+	// To work it around the following two lines set verbosity manually, so the output contains test names (and log
+	// messages from the controller).
+	suiteCfg, repCfg := ginkgo.GinkgoConfiguration()
+	repCfg.Verbose = true
+	ginkgo.RunSpecs(t, "Node IPAM Controller Suite", suiteCfg, repCfg)
 }
 
 var _ = ginkgo.BeforeSuite(func() {

--- a/pkg/controller/ipam/multi_cidr_range_allocator.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator.go
@@ -396,7 +396,7 @@ func (r *multiCIDRRangeAllocator) processNextCIDRWorkItem(ctx context.Context) b
 		// Finally, if no error occurs we Forget this item so it does not
 		// get cidrQueued again until another change happens.
 		r.cidrQueue.Forget(obj)
-		logger.Info("Successfully synced", "key", key)
+		logger.Info("Successfully synced cidr", "key", key)
 		return nil
 	}(ctx, obj)
 	if err != nil {
@@ -454,7 +454,7 @@ func (r *multiCIDRRangeAllocator) processNextNodeWorkItem(ctx context.Context) b
 		// Finally, if no error occurs we Forget this item so it does not
 		// get nodeQueue again until another change happens.
 		r.nodeQueue.Forget(obj)
-		logger.Info("Successfully synced", "key", key)
+		logger.Info("Successfully synced node", "key", key)
 		return nil
 	}(klog.FromContext(ctx), obj)
 	if err != nil {


### PR DESCRIPTION
Wait until ClusterCIDR is created before updating it.
This PR also manually configures ginkgo so now output [contains](https://github.com/kubernetes-sigs/node-ipam-controller/actions/runs/10829236303/job/30046344468?pr=34#step:4:283) all test names.