### PR TITLE
Reconcile ClusterCIDRs with Finalizers

### DIFF
--- a/pkg/controller/ipam/multi_cidr_range_allocator.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"reflect"
 	"slices"
 	"sync"
 	"time"
@@ -234,6 +235,10 @@ func NewMultiCIDRRangeAllocator(
 			}
 		},
 		UpdateFunc: func(old, new interface{}) {
+			if reflect.DeepEqual(old, new) {
+				return
+			}
+
 			key, err := cache.MetaNamespaceKeyFunc(new)
 			if err == nil {
 				ra.cidrQueue.Add(key)

--- a/pkg/controller/ipam/multi_cidr_range_allocator.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"reflect"
 	"slices"
 	"sync"
 	"time"
@@ -37,6 +36,7 @@ import (
 	"sigs.k8s.io/node-ipam-controller/pkg/util/slice"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -235,7 +235,7 @@ func NewMultiCIDRRangeAllocator(
 			}
 		},
 		UpdateFunc: func(old, new interface{}) {
-			if reflect.DeepEqual(old, new) {
+			if apiequality.Semantic.DeepEqual(old, new) {
 				return
 			}
 


### PR DESCRIPTION
Currently, when a finalizer is present a ClusterCIDR reconciliation (create/update) is skipped. Since users can create ClusterCIDRs with finalizers already in the ClusterCIDR definition it leads to problem described in #17.
This patch makes the following changes:
 - reconcile ClusterCIDRs even if finalizers are present
 - make [createClusterCIDR](https://github.com/kubernetes-sigs/node-ipam-controller/blob/0a1e0fdb6eb8f0308b52e84fddff9f322334c077/pkg/controller/ipam/multi_cidr_range_allocator.go#L1128) idempotent by checking if a clusterCIDR is already present in the [cidrMap](https://github.com/kubernetes-sigs/node-ipam-controller/pull/37/files#diff-05114ce7f324f023b63befa2d09eae97b5c22ca057fe62ca9666c03ab8ea0a05R1210).

Performance concerns: 
 - for each ClusterCIDR modification the clusterCIDRList in the cidrmap will be traversed. Iterating through a slice even with a thousand elements (nodes) should not be a problem
 - for each modification the allocator will issue the ClusterCIDR update. Again, it should not be a problem since ClusterCIDRs are immutable and such updates should not happen (often). See also #38.

Moving finalizer logic from `createClusterCIDR` requires changes in `syncClusterCIDR` signature since if it does not return an error [cidrQueue forgets](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/pkg/controller/ipam/multi_cidr_range_allocator.go#L398) the event. I'll do it in a separate PR to keep this small.

Fixes #17 