### PR TITLE
fix: typo in metrics definition

### DIFF
--- a/pkg/controller/ipam/multicidrset/metrics.go
+++ b/pkg/controller/ipam/multicidrset/metrics.go
@@ -43,7 +43,7 @@ var (
 	cidrSetMaxCidrs = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: nodeIpamSubsystem,
-			Name:      "multicirdset_max_cidrs",
+			Name:      "multicidrset_max_cidrs",
 			Help:      "Maximum number of CIDRs that can be allocated.",
 		},
 		[]string{"clusterCIDR"},


### PR DESCRIPTION
See [here](https://github.com/kubernetes-sigs/node-ipam-controller/issues/44#issuecomment-2567427841): fix for typo in the metrics naming.

cc @mneverov 