### PR TITLE
Add ClusterCIDR name to MultiCIDRSet to track metrics correctly.

### DIFF
--- a/pkg/controller/ipam/multi_cidr_priority_queue_test.go
+++ b/pkg/controller/ipam/multi_cidr_priority_queue_test.go
@@ -154,7 +154,7 @@ func TestLess(t *testing.T) {
 
 func createTestPriorityQueueItem(name, cidr, selectorString string, labelMatchCount, perNodeHostBits int) *PriorityQueueItem {
 	_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(cidr)
-	cidrSet, _ := multicidrset.NewMultiCIDRSet(clusterCIDR, perNodeHostBits)
+	cidrSet, _ := multicidrset.NewMultiCIDRSet(name, clusterCIDR, perNodeHostBits)
 
 	return &PriorityQueueItem{
 		clusterCIDR: &multicidrset.ClusterCIDR{

--- a/pkg/controller/ipam/multi_cidr_range_allocator.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator.go
@@ -1181,7 +1181,9 @@ func (r *multiCIDRRangeAllocator) createClusterCIDRSet(clusterCIDR *v1.ClusterCI
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse provided IPv4 CIDR: %w", err)
 		}
-		clusterCIDRSet.IPv4CIDRSet, err = cidrset.NewMultiCIDRSet(ipv4CIDR, int(clusterCIDR.Spec.PerNodeHostBits))
+		clusterCIDRSet.IPv4CIDRSet, err = cidrset.NewMultiCIDRSet(
+			clusterCIDR.Name, ipv4CIDR, int(clusterCIDR.Spec.PerNodeHostBits),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create IPv4 cidrSet: %w", err)
 		}
@@ -1192,7 +1194,9 @@ func (r *multiCIDRRangeAllocator) createClusterCIDRSet(clusterCIDR *v1.ClusterCI
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse provided IPv6 CIDR: %w", err)
 		}
-		clusterCIDRSet.IPv6CIDRSet, err = cidrset.NewMultiCIDRSet(ipv6CIDR, int(clusterCIDR.Spec.PerNodeHostBits))
+		clusterCIDRSet.IPv6CIDRSet, err = cidrset.NewMultiCIDRSet(
+			clusterCIDR.Name, ipv6CIDR, int(clusterCIDR.Spec.PerNodeHostBits),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create IPv6 cidrSet: %w", err)
 		}

--- a/pkg/controller/ipam/multi_cidr_range_allocator_test.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator_test.go
@@ -103,12 +103,12 @@ func getTestCidrMap(testClusterCIDRMap map[string][]*testClusterCIDR) map[string
 
 			if testClusterCIDR.ipv4CIDR != "" {
 				_, testCIDR, _ := utilnet.ParseCIDRSloppy(testClusterCIDR.ipv4CIDR)
-				testCIDRSet, _ := multicidrset.NewMultiCIDRSet(testCIDR, int(testClusterCIDR.perNodeHostBits))
+				testCIDRSet, _ := multicidrset.NewMultiCIDRSet(clusterCIDR.Name, testCIDR, int(testClusterCIDR.perNodeHostBits))
 				clusterCIDR.IPv4CIDRSet = testCIDRSet
 			}
 			if testClusterCIDR.ipv6CIDR != "" {
 				_, testCIDR, _ := utilnet.ParseCIDRSloppy(testClusterCIDR.ipv6CIDR)
-				testCIDRSet, _ := multicidrset.NewMultiCIDRSet(testCIDR, int(testClusterCIDR.perNodeHostBits))
+				testCIDRSet, _ := multicidrset.NewMultiCIDRSet(clusterCIDR.Name, testCIDR, int(testClusterCIDR.perNodeHostBits))
 				clusterCIDR.IPv6CIDRSet = testCIDRSet
 			}
 			clusterCIDRList = append(clusterCIDRList, clusterCIDR)

--- a/pkg/controller/ipam/multicidrset/metrics.go
+++ b/pkg/controller/ipam/multicidrset/metrics.go
@@ -29,7 +29,7 @@ var (
 			Name:      "multicidrset_cidrs_allocations_total",
 			Help:      "Counter measuring total number of CIDR allocations.",
 		},
-		[]string{"clusterCIDR"},
+		[]string{"clusterCIDR", "clusterCIDRName"},
 	)
 	cidrSetReleases = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -37,7 +37,7 @@ var (
 			Name:      "multicidrset_cidrs_releases_total",
 			Help:      "Counter measuring total number of CIDR releases.",
 		},
-		[]string{"clusterCIDR"},
+		[]string{"clusterCIDR", "clusterCIDRName"},
 	)
 	// This is a gauge, as in theory, a limit can increase or decrease.
 	cidrSetMaxCidrs = prometheus.NewGaugeVec(
@@ -46,7 +46,7 @@ var (
 			Name:      "multicidrset_max_cidrs",
 			Help:      "Maximum number of CIDRs that can be allocated.",
 		},
-		[]string{"clusterCIDR"},
+		[]string{"clusterCIDR", "clusterCIDRName"},
 	)
 	cidrSetUsage = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -54,7 +54,7 @@ var (
 			Name:      "multicidrset_usage_cidrs",
 			Help:      "Gauge measuring percentage of allocated CIDRs.",
 		},
-		[]string{"clusterCIDR"},
+		[]string{"clusterCIDR", "clusterCIDRName"},
 	)
 	cidrSetAllocationTriesPerRequest = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -63,7 +63,7 @@ var (
 			Help:      "Histogram measuring CIDR allocation tries per request.",
 			Buckets:   prometheus.ExponentialBuckets(1, 5, 5),
 		},
-		[]string{"clusterCIDR"},
+		[]string{"clusterCIDR", "clusterCIDRName"},
 	)
 )
 

--- a/pkg/controller/ipam/multicidrset/multi_cidr_set_test.go
+++ b/pkg/controller/ipam/multicidrset/multi_cidr_set_test.go
@@ -59,7 +59,7 @@ func TestCIDRSetFullyAllocated(t *testing.T) {
 	}
 	for _, tc := range cases {
 		_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(tc.clusterCIDRStr)
-		a, err := NewMultiCIDRSet(clusterCIDR, tc.perNodeHostBits)
+		a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, tc.perNodeHostBits)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
@@ -210,7 +210,7 @@ func TestIndexToCIDRBlock(t *testing.T) {
 	}
 	for _, tc := range cases {
 		_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(tc.clusterCIDRStr)
-		a, err := NewMultiCIDRSet(clusterCIDR, tc.perNodeHostBits)
+		a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, tc.perNodeHostBits)
 		if err != nil {
 			t.Fatalf("error for %v ", tc.description)
 		}
@@ -240,7 +240,7 @@ func TestCIDRSet_RandomishAllocation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(tc.clusterCIDRStr)
-		a, err := NewMultiCIDRSet(clusterCIDR, 8)
+		a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, 8)
 		if err != nil {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
 		}
@@ -300,7 +300,7 @@ func TestCIDRSet_AllocationOccupied(t *testing.T) {
 	}
 	for _, tc := range cases {
 		_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(tc.clusterCIDRStr)
-		a, err := NewMultiCIDRSet(clusterCIDR, 8)
+		a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, 8)
 		if err != nil {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
 		}
@@ -412,7 +412,7 @@ func TestDoubleOccupyRelease(t *testing.T) {
 	numAllocatable24s := (1 << 8) - 3
 
 	_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(clusterCIDRStr)
-	a, err := NewMultiCIDRSet(clusterCIDR, 8)
+	a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, 8)
 	if err != nil {
 		t.Fatalf("Error allocating CIDRSet")
 	}
@@ -575,7 +575,7 @@ func TestGetBitforCIDR(t *testing.T) {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
 
-		cs, err := NewMultiCIDRSet(clusterCIDR, tc.perNodeHostBits)
+		cs, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, tc.perNodeHostBits)
 		if err != nil {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
 		}
@@ -636,7 +636,7 @@ func TestCIDRSetv6(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
 			_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(tc.clusterCIDRStr)
-			a, err := NewMultiCIDRSet(clusterCIDR, tc.perNodeHostBits)
+			a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, tc.perNodeHostBits)
 			if gotErr := err != nil; gotErr != tc.expectErr {
 				t.Fatalf("NewMultiCIDRSet(%v, %v) = %v, %v; gotErr = %t, want %t", clusterCIDR, tc.perNodeHostBits, a, err, gotErr, tc.expectErr)
 			}
@@ -677,7 +677,7 @@ func TestMultiCIDRSetMetrics(t *testing.T) {
 	clearMetrics(map[string]string{"clusterCIDR": cidr})
 
 	// We have 256 free cidrs
-	a, err := NewMultiCIDRSet(clusterCIDR, 8)
+	a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, 8)
 	if err != nil {
 		t.Fatalf("unexpected error creating MultiCIDRSet: %v", err)
 	}
@@ -734,10 +734,10 @@ func TestMultiCIDRSetMetrics(t *testing.T) {
 func TestMultiCIDRSetMetricsHistogram(t *testing.T) {
 	cidr := "10.0.0.0/16"
 	_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(cidr)
-	clearMetrics(map[string]string{"clusterCIDR": cidr})
+	clearMetrics(map[string]string{"clusterCIDR": cidr, "clusterCIDRName": "test-cluster-cidr"})
 
 	// We have 256 free cidrs.
-	a, err := NewMultiCIDRSet(clusterCIDR, 8)
+	a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, 8)
 	if err != nil {
 		t.Fatalf("unexpected error creating MultiCIDRSet: %v", err)
 	}
@@ -783,9 +783,9 @@ func TestMultiCIDRSetMetricsDual(t *testing.T) {
 	// create IPv4 cidrSet.
 	cidrIPv4 := "10.0.0.0/16"
 	_, clusterCIDRv4, _ := utilnet.ParseCIDRSloppy(cidrIPv4)
-	clearMetrics(map[string]string{"clusterCIDR": cidrIPv4})
+	clearMetrics(map[string]string{"clusterCIDR": cidrIPv4, "clusterCIDRName": "test-cluster-cidr"})
 
-	a, err := NewMultiCIDRSet(clusterCIDRv4, 8)
+	a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDRv4, 8)
 	if err != nil {
 		t.Fatalf("unexpected error creating MultiCIDRSet: %v", err)
 	}
@@ -804,9 +804,9 @@ func TestMultiCIDRSetMetricsDual(t *testing.T) {
 	// create IPv6 cidrSet.
 	cidrIPv6 := "2001:db8::/48"
 	_, clusterCIDRv6, _ := utilnet.ParseCIDRSloppy(cidrIPv6)
-	clearMetrics(map[string]string{"clusterCIDR": cidrIPv6})
+	clearMetrics(map[string]string{"clusterCIDR": cidrIPv6, "clusterCIDRName": "test-cluster-cidr"})
 
-	b, err := NewMultiCIDRSet(clusterCIDRv6, 64)
+	b, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDRv6, 64)
 	if err != nil {
 		t.Fatalf("unexpected error creating MultiCIDRSet: %v", err)
 	}
@@ -922,23 +922,25 @@ type testMetrics struct {
 func expectMetrics(t *testing.T, label string, em testMetrics) {
 	var m testMetrics
 	var err error
-	m.usage, err = testutil.GetGaugeMetricValue(cidrSetUsage.WithLabelValues(label))
+	m.usage, err = testutil.GetGaugeMetricValue(cidrSetUsage.WithLabelValues(label, "test-cluster-cidr"))
 	if err != nil {
 		t.Errorf("failed to get cidr usage value, err: %v", err)
 	}
-	m.allocs, err = testutil.GetCounterMetricValue(cidrSetAllocations.WithLabelValues(label))
+	m.allocs, err = testutil.GetCounterMetricValue(cidrSetAllocations.WithLabelValues(label, "test-cluster-cidr"))
 	if err != nil {
 		t.Errorf("failed to get cidr allocations value, err: %v", err)
 	}
-	m.releases, err = testutil.GetCounterMetricValue(cidrSetReleases.WithLabelValues(label))
+	m.releases, err = testutil.GetCounterMetricValue(cidrSetReleases.WithLabelValues(label, "test-cluster-cidr"))
 	if err != nil {
 		t.Errorf("failed to get cidr releases value, err: %v", err)
 	}
-	m.allocTries, err = testutil.GetHistogramMetricValue(cidrSetAllocationTriesPerRequest.WithLabelValues(label))
+	m.allocTries, err = testutil.GetHistogramMetricValue(
+		cidrSetAllocationTriesPerRequest.WithLabelValues(label, "test-cluster-cidr"),
+	)
 	if err != nil {
 		t.Errorf("failed to get cidr allocation tries value, err: %v", err)
 	}
-	m.max, err = testutil.GetGaugeMetricValue(cidrSetMaxCidrs.WithLabelValues(label))
+	m.max, err = testutil.GetGaugeMetricValue(cidrSetMaxCidrs.WithLabelValues(label, "test-cluster-cidr"))
 	if err != nil {
 		t.Errorf("failed to get max cidrs value, err: %v", err)
 	}
@@ -951,7 +953,7 @@ func expectMetrics(t *testing.T, label string, em testMetrics) {
 // Benchmarks
 func benchmarkAllocateAllIPv6(cidr string, perNodeHostBits int, b *testing.B) {
 	_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(cidr)
-	a, _ := NewMultiCIDRSet(clusterCIDR, perNodeHostBits)
+	a, _ := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, perNodeHostBits)
 	for n := 0; n < b.N; n++ {
 		// Allocate the whole range + 1.
 		for i := 0; i <= a.MaxCIDRs; i++ {


### PR DESCRIPTION
With this change the metrics will have two labels: cidr and cidr name.

Fixes #44 