### PR TITLE
chore: code quality improvements

### DIFF
--- a/pkg/controller/ipam/multi_cidr_range_allocator.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator.go
@@ -242,12 +242,14 @@ func NewMultiCIDRRangeAllocator(
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			// IndexerInformer uses a delta nodeQueue, therefore for deletes we have to use this
+			// IndexerInformer uses a delta cidrQueue, therefore for deletes we have to use this
 			// key function.
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-			if err == nil {
-				ra.cidrQueue.Add(key)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("couldn't get key for cidr %+v: %w", obj, err))
+				return
 			}
+			ra.cidrQueue.Add(key)
 		},
 	})
 	if err != nil {
@@ -298,19 +300,7 @@ func NewMultiCIDRRangeAllocator(
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			// The informer cache no longer has the object, and since Node doesn't have a finalizer,
-			// we don't see the Update with DeletionTimestamp != 0.
-			// TODO: instead of executing the operation directly in the handler, build a small cache with key node.Name
-			// and value PodCIDRs use ReleaseCIDR on the reconcile loop so we can retry on `ReleaseCIDR` failures.
-			if err := ra.ReleaseCIDR(logger, obj.(*corev1.Node)); err != nil {
-				logger.Error(err, "failed to release CIDR")
-			}
-			// IndexerInformer uses a delta nodeQueue, therefore for deletes we have to use this
-			// key function.
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-			if err == nil {
-				ra.nodeQueue.Add(key)
-			}
+			ra.handleNodeDelete(logger, obj)
 		},
 	})
 	if err != nil {
@@ -318,6 +308,39 @@ func NewMultiCIDRRangeAllocator(
 	}
 
 	return ra, nil
+}
+
+func (r *multiCIDRRangeAllocator) handleNodeDelete(logger klog.Logger, obj interface{}) {
+	// IndexerInformer uses a delta nodeQueue, therefore for deletes we have to use this
+	// key function.
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for node %+v: %w", obj, err))
+		return
+	}
+
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			return
+		}
+		node, ok = tombstone.Obj.(*corev1.Node)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Node %+v", obj))
+			return
+		}
+	}
+
+	// The informer cache no longer has the object, and since Node doesn't have a finalizer,
+	// we don't see the Update with DeletionTimestamp != 0.
+	// TODO: instead of executing the operation directly in the handler, build a small cache with key node.Name
+	// and value PodCIDRs use ReleaseCIDR on the reconcile loop so we can retry on `ReleaseCIDR` failures.
+	if err := r.ReleaseCIDR(logger, node); err != nil {
+		logger.Error(err, "failed to release CIDR")
+	}
+	r.nodeQueue.Add(key)
 }
 
 func (r *multiCIDRRangeAllocator) Run(ctx context.Context) {

--- a/pkg/controller/ipam/multi_cidr_range_allocator.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator.go
@@ -311,14 +311,6 @@ func NewMultiCIDRRangeAllocator(
 }
 
 func (r *multiCIDRRangeAllocator) handleNodeDelete(logger klog.Logger, obj interface{}) {
-	// IndexerInformer uses a delta nodeQueue, therefore for deletes we have to use this
-	// key function.
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for node %+v: %w", obj, err))
-		return
-	}
-
 	node, ok := obj.(*corev1.Node)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -333,14 +325,9 @@ func (r *multiCIDRRangeAllocator) handleNodeDelete(logger klog.Logger, obj inter
 		}
 	}
 
-	// The informer cache no longer has the object, and since Node doesn't have a finalizer,
-	// we don't see the Update with DeletionTimestamp != 0.
-	// TODO: instead of executing the operation directly in the handler, build a small cache with key node.Name
-	// and value PodCIDRs use ReleaseCIDR on the reconcile loop so we can retry on `ReleaseCIDR` failures.
 	if err := r.ReleaseCIDR(logger, node); err != nil {
 		logger.Error(err, "failed to release CIDR")
 	}
-	r.nodeQueue.Add(key)
 }
 
 func (r *multiCIDRRangeAllocator) Run(ctx context.Context) {
@@ -480,8 +467,6 @@ func (r *multiCIDRRangeAllocator) syncNode(logger klog.Logger, key string) error
 	node, err := r.nodeLister.Get(key)
 	if apierrors.IsNotFound(err) {
 		logger.V(3).Info("node has been deleted", "node", key)
-		// TODO: obtain the node object information to call ReleaseCIDR from here
-		// and retry if there is an error.
 		return nil
 	}
 	if err != nil {

--- a/pkg/controller/ipam/multi_cidr_range_allocator.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator.go
@@ -75,9 +75,6 @@ const (
 	// The no. of NodeSpec updates NC can process concurrently.
 	cidrUpdateWorkers = 30
 
-	// The max no. of NodeSpec updates that can be enqueued.
-	cidrUpdateQueueSize = 5000
-
 	// cidrUpdateRetries is the no. of times a NodeSpec update will be retried before dropping it.
 	cidrUpdateRetries = 3
 )
@@ -137,11 +134,8 @@ type multiCIDRRangeAllocator struct {
 	clusterCIDRLister clustercidrlisters.ClusterCIDRLister
 	// clusterCIDRSynced returns true if the clustercidr shared informer has been synced at least once.
 	clusterCIDRSynced cache.InformerSynced
-	// Channel that is used to pass updating Nodes and their reserved CIDRs to the background.
-	// This increases a throughput of CIDR assignment by not blocking on long operations.
-	nodeCIDRUpdateChannel chan multiCIDRNodeReservedCIDRs
-	broadcaster           record.EventBroadcaster
-	recorder              record.EventRecorder
+	broadcaster       record.EventBroadcaster
+	recorder          record.EventRecorder
 	// queues are where incoming work is placed to de-dup and to allow "easy"
 	// rate limited requeues on errors
 	cidrQueue workqueue.TypedRateLimitingInterface[string]
@@ -183,15 +177,14 @@ func NewMultiCIDRRangeAllocator(
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, eventSource)
 
 	ra := &multiCIDRRangeAllocator{
-		client:                client,
-		networkClient:         networkClient,
-		nodeLister:            nodeInformer.Lister(),
-		nodesSynced:           nodeInformer.Informer().HasSynced,
-		clusterCIDRLister:     clusterCIDRInformer.Lister(),
-		clusterCIDRSynced:     clusterCIDRInformer.Informer().HasSynced,
-		nodeCIDRUpdateChannel: make(chan multiCIDRNodeReservedCIDRs, cidrUpdateQueueSize),
-		broadcaster:           eventBroadcaster,
-		recorder:              recorder,
+		client:            client,
+		networkClient:     networkClient,
+		nodeLister:        nodeInformer.Lister(),
+		nodesSynced:       nodeInformer.Informer().HasSynced,
+		clusterCIDRLister: clusterCIDRInformer.Lister(),
+		clusterCIDRSynced: clusterCIDRInformer.Informer().HasSynced,
+		broadcaster:       eventBroadcaster,
+		recorder:          recorder,
 		cidrQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "multi_cidr_range_allocator_cidr"},

--- a/pkg/controller/ipam/multi_cidr_range_allocator.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator.go
@@ -503,57 +503,53 @@ func (r *multiCIDRRangeAllocator) syncClusterCIDR(ctx context.Context, key strin
 
 // occupyCIDRs marks node.PodCIDRs[...] as used in allocator's tracked cidrSet.
 func (r *multiCIDRRangeAllocator) occupyCIDRs(logger klog.Logger, node *corev1.Node) error {
-	err := func(node *corev1.Node) error {
-		if len(node.Spec.PodCIDRs) == 0 {
+	if len(node.Spec.PodCIDRs) == 0 {
+		return nil
+	}
+	clusterCIDRList, err := r.orderedMatchingClusterCIDRs(node, true)
+	if err != nil {
+		return err
+	}
+
+	// There can be clusters with nodes that were handled by a different IPAM controller, in order to allow
+	// migrations to the new IPAM controller users can create a ClusterCIDR matching their values, but they may
+	// not want to do that because they just want to get rid of that specific range. In the other hand, users
+	// may not be aware of this problem and they may want to add a new CIDR, so letting the reconcile loop
+	// fail and retry a couple of time can provide information to these users.
+	// https://github.com/kubernetes-sigs/node-ipam-controller/issues/27
+	if len(clusterCIDRList) == 0 {
+		return fmt.Errorf("could not occupy cidrs: %v, No matching ClusterCIDRs found", node.Spec.PodCIDRs)
+	}
+
+	attempts := 0
+	for _, clusterCIDR := range clusterCIDRList {
+		occupiedCount := 0
+		attempts++
+
+		for _, cidr := range node.Spec.PodCIDRs {
+			_, podCIDR, err := netutil.ParseCIDRSloppy(cidr)
+			if err != nil {
+				return fmt.Errorf("failed to parse CIDR %s on Node %v: %w", cidr, node.Name, err)
+			}
+
+			logger.Info("occupy CIDR for node", "CIDR", cidr, "node", klog.KObj(node))
+
+			if err := r.Occupy(clusterCIDR, podCIDR); err != nil {
+				logger.V(3).Info("Could not occupy cidr, trying next range", "podCIDRs", node.Spec.PodCIDRs, "err", err)
+				break
+			}
+
+			occupiedCount++
+		}
+
+		// Mark CIDRs as occupied only if the CCC is able to occupy all the node CIDRs.
+		if occupiedCount == len(node.Spec.PodCIDRs) {
+			clusterCIDR.AssociatedNodes[node.Name] = true
 			return nil
 		}
-		clusterCIDRList, err := r.orderedMatchingClusterCIDRs(node, true)
-		if err != nil {
-			return err
-		}
+	}
 
-		// There can be clusters with nodes that were handled by a different IPAM controller, in order to allow
-		// migrations to the new IPAM controller users can create a ClusterCIDR matching their values, but they may
-		// not want to do that because they just want to get rid of that specific range. In the other hand, users
-		// may not be aware of this problem and they may want to add a new CIDR, so letting the reconcile loop
-		// fail and retry a couple of time can provide information to these users.
-		// https://github.com/kubernetes-sigs/node-ipam-controller/issues/27
-		if len(clusterCIDRList) == 0 {
-			return fmt.Errorf("could not occupy cidrs: %v, No matching ClusterCIDRs found", node.Spec.PodCIDRs)
-		}
-
-		attempts := 0
-		for _, clusterCIDR := range clusterCIDRList {
-			occupiedCount := 0
-			attempts++
-
-			for _, cidr := range node.Spec.PodCIDRs {
-				_, podCIDR, err := netutil.ParseCIDRSloppy(cidr)
-				if err != nil {
-					return fmt.Errorf("failed to parse CIDR %s on Node %v: %w", cidr, node.Name, err)
-				}
-
-				logger.Info("occupy CIDR for node", "CIDR", cidr, "node", klog.KObj(node))
-
-				if err := r.Occupy(clusterCIDR, podCIDR); err != nil {
-					logger.V(3).Info("Could not occupy cidr, trying next range", "podCIDRs", node.Spec.PodCIDRs, "err", err)
-					break
-				}
-
-				occupiedCount++
-			}
-
-			// Mark CIDRs as occupied only if the CCC is able to occupy all the node CIDRs.
-			if occupiedCount == len(node.Spec.PodCIDRs) {
-				clusterCIDR.AssociatedNodes[node.Name] = true
-				return nil
-			}
-		}
-
-		return fmt.Errorf("could not occupy cidrs: %v after %d attempts", node.Spec.PodCIDRs, attempts)
-	}(node)
-
-	return err
+	return fmt.Errorf("could not occupy cidrs: %v after %d attempts", node.Spec.PodCIDRs, attempts)
 }
 
 // associatedCIDRSet returns the CIDRSet, based on the ip family of the CIDR.
@@ -710,66 +706,64 @@ func (r *multiCIDRRangeAllocator) occupyServiceCIDR(clusterCIDR *cidrset.Cluster
 
 // updateCIDRsAllocation assigns CIDR to Node and sends an update to the API server.
 func (r *multiCIDRRangeAllocator) updateCIDRsAllocation(logger klog.Logger, data multiCIDRNodeReservedCIDRs) error {
-	err := func(data multiCIDRNodeReservedCIDRs) error {
-		cidrsString := ipnetToStringList(data.allocatedCIDRs)
-		node, err := r.nodeLister.Get(data.nodeName)
-		if err != nil {
-			logger.Error(err, "Failed while getting node for updating Node.Spec.PodCIDRs", "node", klog.KRef("", data.nodeName))
-			return err
-		}
+	cidrsString := ipnetToStringList(data.allocatedCIDRs)
+	node, err := r.nodeLister.Get(data.nodeName)
+	if err != nil {
+		logger.Error(err, "Failed while getting node for updating Node.Spec.PodCIDRs", "node", klog.KRef("", data.nodeName))
+		return err
+	}
 
-		// if cidr list matches the proposed,
-		// then we possibly updated this node
-		// and just failed to ack the success.
-		if len(node.Spec.PodCIDRs) == len(data.allocatedCIDRs) {
-			match := true
-			for idx, cidr := range cidrsString {
-				if node.Spec.PodCIDRs[idx] != cidr {
-					match = false
-					break
-				}
-			}
-			if match {
-				logger.V(4).Info("Node already has allocated CIDR. It matches the proposed one.", "node", klog.KObj(node), "CIDRs", data.allocatedCIDRs)
-				return nil
+	// if cidr list matches the proposed,
+	// then we possibly updated this node
+	// and just failed to ack the success.
+	if len(node.Spec.PodCIDRs) == len(data.allocatedCIDRs) {
+		match := true
+		for idx, cidr := range cidrsString {
+			if node.Spec.PodCIDRs[idx] != cidr {
+				match = false
+				break
 			}
 		}
-
-		// node has cidrs allocated, release the reserved.
-		if len(node.Spec.PodCIDRs) != 0 {
-			logger.Error(nil, "Node already has a CIDR allocated. Releasing the new one", "node", klog.KObj(node), "podCIDRs", node.Spec.PodCIDRs)
-			for _, cidr := range data.allocatedCIDRs {
-				if err := r.Release(logger, data.clusterCIDR, cidr); err != nil {
-					return fmt.Errorf("failed to release cidr %s from clusterCIDR %s for node: %s: %w", cidr, data.clusterCIDR.Name, node.Name, err)
-				}
-			}
+		if match {
+			logger.V(4).Info("Node already has allocated CIDR. It matches the proposed one.", "node", klog.KObj(node), "CIDRs", data.allocatedCIDRs)
 			return nil
 		}
+	}
 
-		// If we reached here, it means that the node has no CIDR currently assigned. So we set it.
-		for i := 0; i < cidrUpdateRetries; i++ {
-			if err = nodeutil.PatchNodeCIDRs(context.Background(), r.client, types.NodeName(node.Name), cidrsString); err == nil {
-				data.clusterCIDR.AssociatedNodes[node.Name] = true
-				logger.Info("Set node PodCIDR", "node", klog.KObj(node), "podCIDR", cidrsString)
-				return nil
+	// node has cidrs allocated, release the reserved.
+	if len(node.Spec.PodCIDRs) != 0 {
+		logger.Error(nil, "Node already has a CIDR allocated. Releasing the new one", "node", klog.KObj(node), "podCIDRs", node.Spec.PodCIDRs)
+		for _, cidr := range data.allocatedCIDRs {
+			if err := r.Release(logger, data.clusterCIDR, cidr); err != nil {
+				return fmt.Errorf("failed to release cidr %s from clusterCIDR %s for node: %s: %w", cidr, data.clusterCIDR.Name, node.Name, err)
 			}
 		}
-		// failed release back to the pool.
-		logger.Error(err, "Failed to update node PodCIDR after attempts", "node", klog.KObj(node), "podCIDR", cidrsString, "retries", cidrUpdateRetries)
-		controllerutil.RecordNodeStatusChange(logger, r.recorder, node, "CIDRAssignmentFailed")
-		// We accept the fact that we may leak CIDRs here. This is safer than releasing
-		// them in case when we don't know if request went through.
-		// NodeController restart will return all falsely allocated CIDRs to the pool.
-		if !apierrors.IsServerTimeout(err) {
-			logger.Error(err, "CIDR assignment for node failed. Releasing allocated CIDR", "node", klog.KObj(node))
-			for _, cidr := range data.allocatedCIDRs {
-				if err := r.Release(logger, data.clusterCIDR, cidr); err != nil {
-					return fmt.Errorf("failed to release cidr %q from clusterCIDR %q for node: %q: %w", cidr, data.clusterCIDR.Name, node.Name, err)
-				}
+		return nil
+	}
+
+	// If we reached here, it means that the node has no CIDR currently assigned. So we set it.
+	for i := 0; i < cidrUpdateRetries; i++ {
+		if err = nodeutil.PatchNodeCIDRs(context.Background(), r.client, types.NodeName(node.Name), cidrsString); err == nil {
+			data.clusterCIDR.AssociatedNodes[node.Name] = true
+			logger.Info("Set node PodCIDR", "node", klog.KObj(node), "podCIDR", cidrsString)
+			return nil
+		}
+	}
+
+	// failed release back to the pool.
+	logger.Error(err, "Failed to update node PodCIDR after attempts", "node", klog.KObj(node), "podCIDR", cidrsString, "retries", cidrUpdateRetries)
+	controllerutil.RecordNodeStatusChange(logger, r.recorder, node, "CIDRAssignmentFailed")
+	// We accept the fact that we may leak CIDRs here. This is safer than releasing
+	// them in case when we don't know if request went through.
+	// NodeController restart will return all falsely allocated CIDRs to the pool.
+	if !apierrors.IsServerTimeout(err) {
+		logger.Error(err, "CIDR assignment for node failed. Releasing allocated CIDR", "node", klog.KObj(node))
+		for _, cidr := range data.allocatedCIDRs {
+			if err := r.Release(logger, data.clusterCIDR, cidr); err != nil {
+				return fmt.Errorf("failed to release cidr %q from clusterCIDR %q for node: %q: %w", cidr, data.clusterCIDR.Name, node.Name, err)
 			}
 		}
-		return err
-	}(data)
+	}
 
 	return err
 }

--- a/pkg/controller/ipam/multi_cidr_range_allocator_test.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator_test.go
@@ -1872,3 +1872,92 @@ func makeNodeSelector(key string, op corev1.NodeSelectorOperator, values []strin
 func NoResyncPeriodFunc() time.Duration {
 	return 0
 }
+
+func TestHandleNodeDeleteWithTombstone(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-node",
+			Labels: map[string]string{"testLabel-0": "node0"},
+		},
+		Spec: corev1.NodeSpec{
+			PodCIDRs: []string{"10.10.0.1/24"},
+		},
+	}
+
+	fakeNodeHandler := &test.FakeNodeHandler{
+		Existing:  []*corev1.Node{node},
+		Clientset: fake.NewClientset(),
+	}
+
+	fakeNodeInformer := test.FakeNodeInformer(fakeNodeHandler)
+	fakeClient := &clustercidrfake.Clientset{}
+	fakeInformerFactory := clustercidrinformer.NewSharedInformerFactory(fakeClient, NoResyncPeriodFunc())
+	fakeClusterCIDRInformer := fakeInformerFactory.Networking().V1().ClusterCIDRs()
+	fakeCIDRClient := clustercidrfake.NewSimpleClientset().NetworkingV1().ClusterCIDRs() //nolint:staticcheck // see https://github.com/kubernetes/kubernetes/issues/126850
+
+	allocatorParams := CIDRAllocatorParams{
+		ServiceCIDR:          nil,
+		SecondaryServiceCIDR: nil,
+	}
+	testCIDRMap := getTestCidrMap(
+		map[string][]*testClusterCIDR{
+			getTestNodeSelector([]testNodeSelectorRequirement{
+				{
+					key:      "testLabel-0",
+					operator: corev1.NodeSelectorOpIn,
+					values:   []string{"node0"},
+				},
+			}): {
+				{
+					name:            "test-cidr",
+					perNodeHostBits: 8,
+					ipv4CIDR:        "10.10.0.0/16",
+				},
+			},
+		})
+
+	nodeList, _ := fakeNodeHandler.List(context.TODO(), metav1.ListOptions{})
+	allocator, err := NewMultiCIDRRangeAllocator(ctx, fakeNodeHandler, fakeCIDRClient, fakeNodeInformer, fakeClusterCIDRInformer, allocatorParams, nodeList, testCIDRMap)
+	require.NoError(t, err)
+
+	ra := allocator.(*multiCIDRRangeAllocator)
+
+	tests := []struct {
+		name string
+		obj  interface{}
+	}{
+		{
+			name: "regular node object",
+			obj:  node,
+		},
+		{
+			name: "DeletedFinalStateUnknown tombstone wrapping a node",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "test-node",
+				Obj: node,
+			},
+		},
+		{
+			name: "DeletedFinalStateUnknown tombstone wrapping a non-node object",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "test-node",
+				Obj: "not-a-node",
+			},
+		},
+		{
+			name: "completely unexpected object type",
+			obj:  "not-a-node",
+		},
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				ra.handleNodeDelete(logger, tc.obj)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Another batch of code quality improvements:

* update channel was unused and removed. See original [refactoring](https://github.com/kubernetes/kubernetes/pull/115529)
* removed unnecessary anonymous function wrappers - `occupyCIDRs` and `updateCIDRsAllocation` wrapped their logic in an immediately-invoked anonymous function with no benefit — just adds indentation
* fixed node deletion handle function. `obj.(*corev1.Node)` panics if the informer gets `DeletedFinalStateUnknown`. Added logic similar to what we have for [deployments](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/deployment/deployment_controller.go#L214)