### PR TITLE
fix: data race in multi CIDR set

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -181,7 +181,8 @@ jobs:
         export E2E_REPORT_DIR=${PWD}/_artifacts
 
         # Run tests
-        /usr/local/bin/ginkgo --nodes=25                  \
+        CGO_ENABLED=1 /usr/local/bin/ginkgo --race        \
+          --nodes=25                                      \
           --focus="Networking Granular Checks"            \
           --skip="Feature|Federation|machinery|PerformanceDNS|DualStack|Disruptive|Serial|Slow|KubeProxy|LoadBalancer|GCE|Netpol|NetworkPolicy|NodeConformance"   \
           /usr/local/bin/e2e.test                         \

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ KUBEBUILDER_ASSETS=$(shell go run sigs.k8s.io/controller-runtime/tools/setup-env
 
 .PHONY: unit-test
 unit-test: manifests generate fmt ## Run tests.
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -coverprofile cover.out -v ./...
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -race -coverprofile cover.out -v ./...
 
 .PHONY: test-charts
 test-charts: ## Lint and test charts.

--- a/pkg/controller/ipam/multi_cidr_range_allocator.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator.go
@@ -875,14 +875,15 @@ func (r *multiCIDRRangeAllocator) cidrInAllocatedList(logger klog.Logger, cidr *
 			cidrSet, err := r.associatedCIDRSet(clusterCIDR, cidr)
 			if err != nil {
 				logger.Error(err, "failed to associate CIDR set")
+				return false
 			}
-			if cidrSet != nil {
-				if ok := cidrSet.AllocatedCIDRMap[cidr.String()]; ok {
-					return true
-				}
+
+			if cidrSet != nil && cidrSet.CIDRAllocated(cidr) {
+				return true
 			}
 		}
 	}
+
 	return false
 }
 
@@ -892,21 +893,15 @@ func (r *multiCIDRRangeAllocator) cidrOverlapWithAllocatedList(logger klog.Logge
 			cidrSet, err := r.associatedCIDRSet(clusterCIDR, cidr)
 			if err != nil {
 				logger.Error(err, "failed to associate CIDR set")
+				return false
 			}
-			if cidrSet != nil {
-				for allocated := range cidrSet.AllocatedCIDRMap {
-					_, allocatedCIDR, err := netutil.ParseCIDRSloppy(allocated)
-					if err != nil {
-						logger.Error(err, "failed to parse CIDR", "cidr", allocated)
-						continue
-					}
-					if cidr.Contains(allocatedCIDR.IP.Mask(cidr.Mask)) || allocatedCIDR.Contains(cidr.IP.Mask(allocatedCIDR.Mask)) {
-						return true
-					}
-				}
+
+			if cidrSet != nil && cidrSet.CIDROverlaps(cidr) {
+				return true
 			}
 		}
 	}
+
 	return false
 }
 

--- a/pkg/controller/ipam/multi_cidr_range_allocator.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator.go
@@ -875,7 +875,7 @@ func (r *multiCIDRRangeAllocator) cidrInAllocatedList(logger klog.Logger, cidr *
 			cidrSet, err := r.associatedCIDRSet(clusterCIDR, cidr)
 			if err != nil {
 				logger.Error(err, "failed to associate CIDR set")
-				return false
+				continue
 			}
 
 			if cidrSet != nil && cidrSet.CIDRAllocated(cidr) {
@@ -893,7 +893,7 @@ func (r *multiCIDRRangeAllocator) cidrOverlapWithAllocatedList(logger klog.Logge
 			cidrSet, err := r.associatedCIDRSet(clusterCIDR, cidr)
 			if err != nil {
 				logger.Error(err, "failed to associate CIDR set")
-				return false
+				continue
 			}
 
 			if cidrSet != nil && cidrSet.CIDROverlaps(cidr) {

--- a/pkg/controller/ipam/multi_cidr_range_allocator_test.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -1836,6 +1837,35 @@ func TestSyncClusterCIDRDeleteWithNodesAssociated(t *testing.T) {
 	cccController.clusterCIDRStore.Update(createdCCC)
 	err = cccController.syncClusterCIDR(ctx, createdCCC.Name)
 	assert.Error(t, err, fmt.Sprintf("ClusterCIDR %s marked as terminating, won't be deleted until all associated nodes are deleted", createdCCC.Name))
+}
+
+func TestMultiCIDRSetDataRace(t *testing.T) {
+	_, cidr, err := utilnet.ParseCIDRSloppy("10.0.0.0/16")
+	require.NoError(t, err)
+
+	cidrSet, err := multicidrset.NewMultiCIDRSet("race-test", cidr, 8)
+	require.NoError(t, err)
+
+	clusterCIDR := &multicidrset.ClusterCIDR{
+		Name:            "race-test",
+		IPv4CIDRSet:     cidrSet,
+		AssociatedNodes: make(map[string]bool),
+	}
+
+	selectorKey := "race-selector"
+	ra := &multiCIDRRangeAllocator{
+		lock:    &sync.Mutex{},
+		cidrMap: map[string][]*multicidrset.ClusterCIDR{selectorKey: {clusterCIDR}},
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	_, lookupCIDR, err := utilnet.ParseCIDRSloppy("10.0.1.0/24")
+	require.NoError(t, err)
+
+	go cidrSet.Occupy(lookupCIDR)
+	go cidrSet.Release(lookupCIDR)
+	go ra.cidrInAllocatedList(logger, lookupCIDR)
+	go ra.cidrOverlapWithAllocatedList(logger, lookupCIDR)
 }
 
 func expectActions(t *testing.T, actions []k8stesting.Action, num int, verb, resource string) {

--- a/pkg/controller/ipam/multi_cidr_range_allocator_test.go
+++ b/pkg/controller/ipam/multi_cidr_range_allocator_test.go
@@ -1862,10 +1862,13 @@ func TestMultiCIDRSetDataRace(t *testing.T) {
 	_, lookupCIDR, err := utilnet.ParseCIDRSloppy("10.0.1.0/24")
 	require.NoError(t, err)
 
-	go cidrSet.Occupy(lookupCIDR)
-	go cidrSet.Release(lookupCIDR)
-	go ra.cidrInAllocatedList(logger, lookupCIDR)
-	go ra.cidrOverlapWithAllocatedList(logger, lookupCIDR)
+	var wg sync.WaitGroup
+	wg.Add(4)
+	go func() { defer wg.Done(); cidrSet.Occupy(lookupCIDR) }()
+	go func() { defer wg.Done(); cidrSet.Release(lookupCIDR) }()
+	go func() { defer wg.Done(); ra.cidrInAllocatedList(logger, lookupCIDR) }()
+	go func() { defer wg.Done(); ra.cidrOverlapWithAllocatedList(logger, lookupCIDR) }()
+	wg.Wait()
 }
 
 func expectActions(t *testing.T, actions []k8stesting.Action, num int, verb, resource string) {

--- a/pkg/controller/ipam/multicidrset/multi_cidr_set.go
+++ b/pkg/controller/ipam/multicidrset/multi_cidr_set.go
@@ -24,13 +24,13 @@ import (
 	"net"
 	"sync"
 
+	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 )
 
 // MultiCIDRSet manages a set of CIDR ranges from which blocks of IPs can
 // be allocated from.
 type MultiCIDRSet struct {
-	sync.Mutex
 	// ClusterCIDR is the CIDR assigned to the cluster.
 	ClusterCIDR *net.IPNet
 	// NodeMaskSize is the mask size, in bits,assigned to the nodes
@@ -42,11 +42,12 @@ type MultiCIDRSet struct {
 	// as Number of allocations, Total number of CIDR releases, Percentage of
 	// allocated CIDRs, Tries required for allocating a CIDR for a particular CIDRSet.
 	Label string
-	// AllocatedCIDRMap stores all the allocated CIDRs from the current CIDRSet.
+
+	// allocatedCIDRMap stores all the allocated CIDRs from the current CIDRSet.
 	// Stores a mapping of the next candidate CIDR for allocation to it's
 	// allocation status. Next candidate is used only if allocation status is false.
-	AllocatedCIDRMap map[string]bool
-
+	// Protected by mu.
+	allocatedCIDRMap map[string]bool
 	// clusterMaskSize is the mask size, in bits, assigned to the cluster.
 	// caches the mask size to avoid the penalty of calling clusterCIDR.Mask.Size().
 	clusterMaskSize int
@@ -54,6 +55,8 @@ type MultiCIDRSet struct {
 	clusterCIDRName string
 	// nodeMask is the network mask assigned to the nodes.
 	nodeMask net.IPMask
+	// mu protects allocatedCIDRMap concurrent access.
+	mu sync.Mutex
 	// allocatedCIDRs counts the number of CIDRs allocated.
 	allocatedCIDRs int
 	// nextCandidate points to the next CIDR that should be free.
@@ -143,7 +146,7 @@ func NewMultiCIDRSet(clusterCIDRName string, cidrConfig *net.IPNet, perNodeHostB
 		MaxCIDRs:         maxCIDRs,
 		NodeMaskSize:     subNetMaskSize,
 		Label:            cidrConfig.String(),
-		AllocatedCIDRMap: make(map[string]bool, 0),
+		allocatedCIDRMap: make(map[string]bool),
 	}
 	cidrSetMaxCidrs.WithLabelValues(multiCIDRSet.Label, clusterCIDRName).Set(float64(maxCIDRs))
 
@@ -198,8 +201,8 @@ func (s *MultiCIDRSet) indexToCIDRBlock(index int) (*net.IPNet, error) {
 // NextCandidate returns the next candidate and the last evaluated index
 // for the current cidrSet. Returns nil if the candidate is already allocated.
 func (s *MultiCIDRSet) NextCandidate() (*net.IPNet, int, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if s.allocatedCIDRs == s.MaxCIDRs {
 		return nil, 0, &CIDRRangeNoCIDRsRemainingErr{
@@ -214,7 +217,7 @@ func (s *MultiCIDRSet) NextCandidate() (*net.IPNet, int, error) {
 			return nil, i, err
 		}
 		// Check if the nextCandidate is not already allocated.
-		if _, ok := s.AllocatedCIDRMap[nextCandidateCIDR.String()]; !ok {
+		if _, ok := s.allocatedCIDRMap[nextCandidateCIDR.String()]; !ok {
 			s.nextCandidate = (candidate + 1) % s.MaxCIDRs
 			return nextCandidateCIDR, i, nil
 		}
@@ -277,8 +280,8 @@ func (s *MultiCIDRSet) Release(cidr *net.IPNet) error {
 	if err != nil {
 		return err
 	}
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	for i := begin; i <= end; i++ {
 		// Remove from the allocated CIDR Map and decrement the counter only if currently
@@ -287,8 +290,8 @@ func (s *MultiCIDRSet) Release(cidr *net.IPNet) error {
 		if err != nil {
 			return err
 		}
-		if _, ok := s.AllocatedCIDRMap[currCIDR.String()]; ok {
-			delete(s.AllocatedCIDRMap, currCIDR.String())
+		if _, ok := s.allocatedCIDRMap[currCIDR.String()]; ok {
+			delete(s.allocatedCIDRMap, currCIDR.String())
 			s.allocatedCIDRs--
 			cidrSetReleases.WithLabelValues(s.Label, s.clusterCIDRName).Inc()
 		}
@@ -306,8 +309,8 @@ func (s *MultiCIDRSet) Occupy(cidr *net.IPNet) (err error) {
 	if err != nil {
 		return err
 	}
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	for i := begin; i <= end; i++ {
 		// Add to the allocated CIDR Map and increment the counter only if not already
@@ -316,8 +319,8 @@ func (s *MultiCIDRSet) Occupy(cidr *net.IPNet) (err error) {
 		if err != nil {
 			return err
 		}
-		if _, ok := s.AllocatedCIDRMap[currCIDR.String()]; !ok {
-			s.AllocatedCIDRMap[currCIDR.String()] = true
+		if _, ok := s.allocatedCIDRMap[currCIDR.String()]; !ok {
+			s.allocatedCIDRMap[currCIDR.String()] = true
 			cidrSetAllocations.WithLabelValues(s.Label, s.clusterCIDRName).Inc()
 			s.allocatedCIDRs++
 		}
@@ -358,4 +361,32 @@ func (s *MultiCIDRSet) UpdateEvaluatedCount(evaluated int) {
 // into subnets with mask of size `subNetMaskSize`.
 func getMaxCIDRs(subNetMaskSize, clusterMaskSize int) int {
 	return 1 << uint32(subNetMaskSize-clusterMaskSize)
+}
+
+// CIDRAllocated returns true if the given CIDR is exactly allocated in the set.
+func (s *MultiCIDRSet) CIDRAllocated(cidr *net.IPNet) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, ok := s.allocatedCIDRMap[cidr.String()]
+	return ok
+}
+
+// CIDROverlaps returns true if the given CIDR overlaps with any allocated CIDR in the set.
+func (s *MultiCIDRSet) CIDROverlaps(cidr *net.IPNet) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for allocated := range s.allocatedCIDRMap {
+		_, allocatedCIDR, err := netutils.ParseCIDRSloppy(allocated)
+		if err != nil {
+			klog.ErrorS(err, "failed to parse CIDR", "cidr", allocated)
+			continue
+		}
+		if cidr.Contains(allocatedCIDR.IP.Mask(cidr.Mask)) || allocatedCIDR.Contains(cidr.IP.Mask(allocatedCIDR.Mask)) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/controller/ipam/multicidrset/multi_cidr_set_test.go
+++ b/pkg/controller/ipam/multicidrset/multi_cidr_set_test.go
@@ -950,6 +950,186 @@ func expectMetrics(t *testing.T, label string, em testMetrics) {
 	}
 }
 
+func TestCIDRAllocated(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr  string
+		perNodeHostBits int
+		description     string
+	}{
+		{
+			clusterCIDRStr:  "10.0.0.0/16",
+			perNodeHostBits: 8,
+			description:     "IPv4",
+		},
+		{
+			clusterCIDRStr:  "2001:db8::/48",
+			perNodeHostBits: 64,
+			description:     "IPv6",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(tc.clusterCIDRStr)
+			multiCIDRSet, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, tc.perNodeHostBits)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			cidr, err := allocateNext(multiCIDRSet)
+			if err != nil {
+				t.Fatalf("failed to allocate: %v", err)
+			}
+			if !multiCIDRSet.CIDRAllocated(cidr) {
+				t.Fatalf("expected CIDR %v to be allocated", cidr)
+			}
+			candidate, _, err := multiCIDRSet.NextCandidate()
+			if err != nil {
+				t.Fatalf("failed to get next CIDR candidate: %v", err)
+			}
+			if multiCIDRSet.CIDRAllocated(candidate) {
+				t.Fatalf("not expected candidate CIDR %v to be allocated", cidr)
+			}
+
+			if err := multiCIDRSet.Release(cidr); err != nil {
+				t.Fatalf("failed to release CIDR: %v", err)
+			}
+			if multiCIDRSet.CIDRAllocated(cidr) {
+				t.Fatalf("expected CIDR %v to not be allocated after release", cidr)
+			}
+		})
+	}
+}
+
+func TestCIDROverlaps(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr  string
+		perNodeHostBits int
+		occupyCIDRStr   string
+		testCIDRStr     string
+		expectOverlap   bool
+		description     string
+	}{
+		{
+			clusterCIDRStr:  "10.0.0.0/16",
+			perNodeHostBits: 8,
+			occupyCIDRStr:   "10.0.5.0/24",
+			testCIDRStr:     "10.0.5.0/24",
+			expectOverlap:   true,
+			description:     "IPv4 exact match overlaps",
+		},
+		{
+			clusterCIDRStr:  "10.0.0.0/16",
+			perNodeHostBits: 8,
+			occupyCIDRStr:   "10.0.5.0/24",
+			testCIDRStr:     "10.0.0.0/16",
+			expectOverlap:   true,
+			description:     "IPv4 larger CIDR containing allocated overlaps",
+		},
+		{
+			clusterCIDRStr:  "10.0.0.0/16",
+			perNodeHostBits: 8,
+			occupyCIDRStr:   "10.0.5.0/24",
+			testCIDRStr:     "10.0.5.128/25",
+			expectOverlap:   true,
+			description:     "IPv4 smaller CIDR within allocated overlaps",
+		},
+		{
+			clusterCIDRStr:  "10.0.0.0/16",
+			perNodeHostBits: 8,
+			occupyCIDRStr:   "10.0.5.0/24",
+			testCIDRStr:     "10.0.6.0/24",
+			expectOverlap:   false,
+			description:     "IPv4 non-overlapping CIDR",
+		},
+		{
+			clusterCIDRStr:  "10.0.0.0/16",
+			perNodeHostBits: 8,
+			occupyCIDRStr:   "10.0.5.0/24",
+			testCIDRStr:     "10.0.4.0/22",
+			expectOverlap:   true,
+			description:     "IPv4 broader CIDR that includes allocated",
+		},
+		{
+			clusterCIDRStr:  "2001:db8::/48",
+			perNodeHostBits: 64,
+			occupyCIDRStr:   "2001:db8:0:1::/64",
+			testCIDRStr:     "2001:db8:0:1::/64",
+			expectOverlap:   true,
+			description:     "IPv6 exact match overlaps",
+		},
+		{
+			clusterCIDRStr:  "2001:db8::/48",
+			perNodeHostBits: 64,
+			occupyCIDRStr:   "2001:db8:0:1::/64",
+			testCIDRStr:     "2001:db8:0:2::/64",
+			expectOverlap:   false,
+			description:     "IPv6 non-overlapping CIDR",
+		},
+		{
+			clusterCIDRStr:  "2001:db8::/48",
+			perNodeHostBits: 64,
+			occupyCIDRStr:   "2001:db8:0:1::/64",
+			testCIDRStr:     "2001:db8::/48",
+			expectOverlap:   true,
+			description:     "IPv6 larger CIDR containing allocated overlaps",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(tc.clusterCIDRStr)
+			a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, tc.perNodeHostBits)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			_, occupyCIDR, _ := utilnet.ParseCIDRSloppy(tc.occupyCIDRStr)
+			if err := a.Occupy(occupyCIDR); err != nil {
+				t.Fatalf("unexpected error occupying CIDR: %v", err)
+			}
+
+			_, testCIDR, _ := utilnet.ParseCIDRSloppy(tc.testCIDRStr)
+			got := a.CIDROverlaps(testCIDR)
+			if got != tc.expectOverlap {
+				t.Fatalf("CIDROverlaps(%v) = %v, want %v", testCIDR, got, tc.expectOverlap)
+			}
+		})
+	}
+
+	t.Run("no allocations", func(t *testing.T) {
+		_, clusterCIDR, _ := utilnet.ParseCIDRSloppy("10.0.0.0/16")
+		a, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, 8)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_, testCIDR, _ := utilnet.ParseCIDRSloppy("10.0.5.0/24")
+		if a.CIDROverlaps(testCIDR) {
+			t.Fatalf("expected no overlap with empty set")
+		}
+	})
+
+	t.Run("no overlap after release", func(t *testing.T) {
+		_, clusterCIDR, _ := utilnet.ParseCIDRSloppy("10.0.0.0/16")
+		multiCIDRSet, err := NewMultiCIDRSet("test-cluster-cidr", clusterCIDR, 8)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_, occupyCIDR, _ := utilnet.ParseCIDRSloppy("10.0.5.0/24")
+		if err := multiCIDRSet.Occupy(occupyCIDR); err != nil {
+			t.Fatalf("unexpected error occupying CIDR: %v", err)
+		}
+		_, testCIDR, _ := utilnet.ParseCIDRSloppy("10.0.4.0/22")
+		if !multiCIDRSet.CIDROverlaps(testCIDR) {
+			t.Fatalf("expected overlap before release")
+		}
+		if err := multiCIDRSet.Release(occupyCIDR); err != nil {
+			t.Fatalf("unexpected error releasing CIDR: %v", err)
+		}
+		if multiCIDRSet.CIDROverlaps(testCIDR) {
+			t.Fatalf("expected no overlap after release")
+		}
+	})
+}
+
 // Benchmarks
 func benchmarkAllocateAllIPv6(cidr string, perNodeHostBits int, b *testing.B) {
 	_, clusterCIDR, _ := utilnet.ParseCIDRSloppy(cidr)


### PR DESCRIPTION
This PR fixes data race in the CIDR allocator.
The allocator [runs 30 workers](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/pkg/controller/ipam/multi_cidr_range_allocator.go#L76) in parallel. It directly access MultiCIDRSet map to check if a CIDR is already [allocated](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/pkg/controller/ipam/multi_cidr_range_allocator.go#L875) or [overlaps](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/pkg/controller/ipam/multi_cidr_range_allocator.go#L892) with other allocated CIDRs. Unlike methods [Occupy](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/pkg/controller/ipam/multicidrset/multi_cidr_set.go#L319) and [Release](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/pkg/controller/ipam/multicidrset/multi_cidr_set.go#L290) this access is not protected by the MultiCIDRSet lock and hence can lead to a data race.
I also made [sync.Mutex](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/pkg/controller/ipam/multicidrset/multi_cidr_set.go#L33) an internal field instead of wrapping it not to expose `Lock()` and `Unlock()` functions because it is implementation details.

There are other public fields in the `MultiCIDRSet` that I want to make private as well as move [metrics related tests](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/pkg/controller/ipam/multicidrset/multi_cidr_set_test.go#L674) in a separate file. This will be a separate PR unless it is fine to also include these changes in this PR.