### PR TITLE
feat: Added Validation For ClusterCIDRSpec and its IPv4 and IPv6 Fields.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ IMAGE_NAME := node-ipam-controller
 IMAGE_REPO := $(IMAGE_REGISTRY)/$(IMAGE_NAME)
 IMG ?= $(IMAGE_REPO):$(GIT_TAG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.27.x
+ENVTEST_K8S_VERSION = 1.31.x
 
 # Use go.mod go version as a single source of truth of GO version.
 GO_VERSION := $(shell awk '/^go /{print $$2}' go.mod|head -n1)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ allocation.
 
 ### Prerequisites
 
-- Kubernetes cluster v1.26+
+- Kubernetes cluster v1.31+
 - [Helm](https://helm.sh/) v3
 - The cluster's built-in node IPAM controller must be disabled
   (`--allocate-node-cidrs=false` on kube-controller-manager)

--- a/charts/node-ipam-controller/gen/crds/networking.x-k8s.io_clustercidrs.yaml
+++ b/charts/node-ipam-controller/gen/crds/networking.x-k8s.io_clustercidrs.yaml
@@ -57,6 +57,9 @@ spec:
                 x-kubernetes-validations:
                 - message: IPv4 cannot be changed.
                   rule: oldSelf == self
+                - message: IPv4 must be a valid IPv4 CIDR.
+                  rule: self == '' || (isCIDR(self) && cidr(self).ip().family() ==
+                    4)
               ipv6:
                 description: |-
                   ipv6 defines an IPv6 IP block in CIDR notation(e.g. "2001:db8::/64").
@@ -66,6 +69,9 @@ spec:
                 x-kubernetes-validations:
                 - message: IPv6 cannot be changed.
                   rule: oldSelf == self
+                - message: IPv6 must be a valid IPv6 CIDR.
+                  rule: self == '' || (isCIDR(self) && cidr(self).ip().family() ==
+                    6)
               nodeSelector:
                 description: |-
                   nodeSelector defines which nodes the config is applicable to.
@@ -177,6 +183,9 @@ spec:
             required:
             - perNodeHostBits
             type: object
+            x-kubernetes-validations:
+            - message: A CIDR must be specified for ipv4 or ipv6.
+              rule: self.ipv4 != '' || self.ipv6 != ''
         type: object
     served: true
     storage: true

--- a/charts/node-ipam-controller/gen/crds/networking.x-k8s.io_clustercidrs.yaml
+++ b/charts/node-ipam-controller/gen/crds/networking.x-k8s.io_clustercidrs.yaml
@@ -185,7 +185,7 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: A CIDR must be specified for ipv4 or ipv6.
-              rule: self.ipv4 != '' || self.ipv6 != ''
+              rule: self.ipv4 != "" || self.ipv6 != ""
         type: object
     served: true
     storage: true

--- a/pkg/apis/clustercidr/v1/types.go
+++ b/pkg/apis/clustercidr/v1/types.go
@@ -47,7 +47,7 @@ type ClusterCIDR struct {
 func (in *ClusterCIDR) Default() {}
 
 // ClusterCIDRSpec defines the desired state of ClusterCIDR.
-// +kubebuilder:validation:XValidation:message="A CIDR must be specified for ipv4 or ipv6.",rule="self.ipv4 != '' || self.ipv6 != ''"
+// +kubebuilder:validation:XValidation:message="A CIDR must be specified for ipv4 or ipv6.",rule="self.ipv4 != \"\" || self.ipv6 != \"\""
 type ClusterCIDRSpec struct {
 	// nodeSelector defines which nodes the config is applicable to.
 	// An empty or nil nodeSelector selects all nodes.

--- a/pkg/apis/clustercidr/v1/types.go
+++ b/pkg/apis/clustercidr/v1/types.go
@@ -47,6 +47,7 @@ type ClusterCIDR struct {
 func (in *ClusterCIDR) Default() {}
 
 // ClusterCIDRSpec defines the desired state of ClusterCIDR.
+// +kubebuilder:validation:XValidation:message="A CIDR must be specified for ipv4 or ipv6.",rule="self.ipv4 != '' || self.ipv6 != ''"
 type ClusterCIDRSpec struct {
 	// nodeSelector defines which nodes the config is applicable to.
 	// An empty or nil nodeSelector selects all nodes.
@@ -72,6 +73,7 @@ type ClusterCIDRSpec struct {
 	// This field is optional and immutable.
 	// +optional
 	// +kubebuilder:validation:XValidation:message="IPv4 cannot be changed.",rule="oldSelf == self"
+	// +kubebuilder:validation:XValidation:message="IPv4 must be a valid IPv4 CIDR.",rule="self == '' || (isCIDR(self) && cidr(self).ip().family() == 4)"
 	IPv4 string `json:"ipv4,omitempty"`
 
 	// ipv6 defines an IPv6 IP block in CIDR notation(e.g. "2001:db8::/64").
@@ -79,6 +81,7 @@ type ClusterCIDRSpec struct {
 	// This field is optional and immutable.
 	// +optional
 	// +kubebuilder:validation:XValidation:message="IPv6 cannot be changed.",rule="oldSelf == self"
+	// +kubebuilder:validation:XValidation:message="IPv6 must be a valid IPv6 CIDR.",rule="self == '' || (isCIDR(self) && cidr(self).ip().family() == 6)"
 	IPv6 string `json:"ipv6,omitempty"`
 }
 

--- a/pkg/controller/ipam/ipam_test.go
+++ b/pkg/controller/ipam/ipam_test.go
@@ -209,6 +209,20 @@ var _ = ginkgo.Describe("Pod CIDRs", ginkgo.Ordered, func() {
 		gomega.Expect(err).Should(gomega.MatchError(gomega.ContainSubstring("IPv6 cannot be changed.")))
 	})
 
+	ginkgo.It("should fail when provided invalid CIDR(s)", func() {
+		originalClusterCIDR := makeClusterCIDR("invalid-cidrs-supplied", "", "", 8, nodeSelector(map[string][]string{"ipv4": {"true"}, "ipv6": {"true"}}))
+		_, err := cidrClient.NetworkingV1().ClusterCIDRs().Create(ctx, originalClusterCIDR, metav1.CreateOptions{})
+		gomega.Expect(err).Should(gomega.MatchError(gomega.ContainSubstring("A CIDR must be specified for ipv4 or ipv6.")))
+
+		originalClusterCIDR = makeClusterCIDR("invalid-ipv4-cidr-supplied", "256.256.256.256/33", "", 8, nodeSelector(map[string][]string{"ipv4": {"true"}, "ipv6": {"true"}}))
+		_, err = cidrClient.NetworkingV1().ClusterCIDRs().Create(ctx, originalClusterCIDR, metav1.CreateOptions{})
+		gomega.Expect(err).Should(gomega.MatchError(gomega.ContainSubstring("IPv4 must be a valid IPv4 CIDR.")))
+
+		originalClusterCIDR = makeClusterCIDR("invalid-ipv6-cidr-supplied", "", "::/129", 8, nodeSelector(map[string][]string{"ipv4": {"true"}, "ipv6": {"true"}}))
+		_, err = cidrClient.NetworkingV1().ClusterCIDRs().Create(ctx, originalClusterCIDR, metav1.CreateOptions{})
+		gomega.Expect(err).Should(gomega.MatchError(gomega.ContainSubstring("IPv6 must be a valid IPv6 CIDR.")))
+	})
+
 	ginkgo.It("should delete ClusterCIDR only after associated node is deleted", func() {
 		// Create a ClusterCIDR.
 		clusterCIDR := makeClusterCIDR("dualstack-cc-del", "192.168.0.0/23", "fd00:30:100::/119", 8, nodeSelector(map[string][]string{"ipv4": {"true"}, "ipv6": {"true"}}))


### PR DESCRIPTION
# Description
* Addresses [Issue#92](https://github.com/kubernetes-sigs/node-ipam-controller/issues/92)
* Bumped Kubernetes Version Specified in README based on [CEL docs](https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-cidr-library)
* Regenerated CRDs
* Added Validation to Top Level ClusterCIDRSpec Struct, IPv4 and/or IPv6 must be populated
* Added Validation to ClusterCIDRSpec.IPv4, is blank OR is valid CIDR of IPv4 family
* Added Validation to ClusterCIDRSpec.IPv6, is blank OR is valid CIDR of IPv6 family