### PR TITLE
Fix/image push

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,16 +17,16 @@ timeout: 3000s
 # A build step specifies an action that you want Prow to perform.
 # For each build step, Prow executes a job.
 steps:
-# see https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
+  # see https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
     entrypoint: make
     args:
       - image-push
     env:
-    - IMAGE_REGISTRY=gcr.io/$PROJECT_ID
-    - GIT_TAG=$_GIT_TAG
-    - EXTRA_TAG=$_PULL_BASE_REF
-    - DOCKER_BUILDX_CMD=/buildx-entrypoint
+      - IMAGE_REGISTRY=gcr.io/$PROJECT_ID
+      - GIT_TAG=$_GIT_TAG
+      - EXTRA_TAG=$_PULL_BASE_REF
+      - DOCKER_BUILDX_CMD=/buildx-entrypoint
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,7 +18,7 @@ timeout: 3000s
 # For each build step, Prow executes a job.
 steps:
 # see https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220830-45cbff55bc
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
     entrypoint: make
     args:
       - image-push


### PR DESCRIPTION
Use latest image of gcb-docker-gcloud for image push.
Fixes #142 